### PR TITLE
use built-in string reading to avoid python3 bytes/str incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# BinaryNinja go loader assist
-
+# GO Loader Assist (v1.1)
 Author: **Michael Rodler**
 
 _Short script that parses go symbol table and renames/creates functions._
@@ -10,32 +9,45 @@ go reversing helpers for binaryninja.
 
 Basically this is some stuff ported from the IDA pro script
 [golang_load_assist](https://github.com/strazzere/golang_loader_assist)
-.
 
-Probably incomplete!
+ Probably incomplete!
 
 ### go reversing blog posts
 
-* http://rednaga.io/2016/09/21/reversing_go_binaries_like_a_pro/
+ * http://rednaga.io/2016/09/21/reversing_go_binaries_like_a_pro/
 
 
+## Installation Instructions
+
+### Darwin
+
+no special instructions, package manager is recommended
+
+### Linux
+
+no special instructions, package manager is recommended
+
+### Windows
+
+no special instructions, package manager is recommended
 
 ## Minimum Version
 
 This plugin requires the following minimum version of Binary Ninja:
 
- * dev - 1.0
+* 1528
+
 
 
 ## Required Dependencies
 
 The following dependencies are required for this plugin:
 
-None
 
 
 ## License
 
-This plugin is released under a [MIT](LICENSE) license.
+This plugin is released under a MIT license.
+## Metadata Version
 
-
+2

--- a/do_release.py
+++ b/do_release.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#Little utility to automatically do a new release.
+from git import Repo
+from json import load, dump
+from github_release import gh_release_create
+from sys import exit
+from os import path
+from argparse import ArgumentParser
+from subprocess import run
+'''WARNING: IF YOU DO NOT UPDATE YOUR README.md USING generate_plugininfo.py 
+THIS PLUGIN WILL OVERWRITE IT!'''
+
+parser = ArgumentParser()
+parser.add_argument("-d", "--description", help="Description for the new release", action="store", dest="description", default="")
+parser.add_argument("-v", "--version", help="New version string", action="store", dest="new_version", default="")
+parser.add_argument("--force", help="Override the repository dirty check", action="store_true", dest="dirtyoverride", default=False)
+args = parser.parse_args()
+#TODO
+
+repo = Repo(".")
+reponame = list(repo.remotes.origin.urls)[0].split(':')[1].split('.')[0]
+if repo.is_dirty() and not args.dirtyoverride:
+	print("Cowardly refusing to do anything as the plugin repository is currently dirty.")
+	exit(-1)
+
+if not path.isfile("./generate_plugininfo.py"):
+	print("Missing ./generate_plugininfo.py.")
+	exit(-1)
+
+with open('plugin.json') as plugin:
+	data = load(plugin)
+
+def update_version(data):
+	print(f"Updating plugin with new version {data['version']}")
+	with open('plugin.json', 'w') as plugin:
+		dump(data, plugin)
+	run(["./generate_plugininfo.py", "-r", "-f"], check=True)
+	repo.index.add('plugin.json')
+	repo.index.add('README.md')
+	if args.description == "":
+		repo.index.commit(f"Updating to {data['version']}")
+	else:
+		repo.index.commit(args.description)
+	repo.git.push('origin')
+
+for tag in repo.tags:
+	if tag.name == data['version']:
+		if args.new_version == "":
+			print(f"Current plugin version {data['version']} is already a tag. Shall I increment it for you?")
+			yn = input("[y/n]: ")
+			if yn == "Y" or yn == "y":
+				digits = data['version'].split('.')
+				newlast = str(int(digits[-1])+1)
+				digits[-1] = newlast
+				inc_version = '.'.join(digits)
+				data['version'] = inc_version
+				update_version(data)
+			else:
+				print("Stopping...")
+				exit(-1)
+		else:
+			data['version'] = args.new_version
+			update_version(data)
+
+# Create new tag
+new_tag = repo.create_tag(data['version'])
+# Push
+repo.remotes.origin.push(data['version'])
+# Create release
+gh_release_create(reponame, data['version'], publish=True, name="%s v%s" % (data['name'], data['version']))

--- a/gohelpers.py
+++ b/gohelpers.py
@@ -46,19 +46,6 @@ class GoHelper(bn.plugin.BackgroundTaskThread):
         else:
             return None
 
-    def read_cstring(self, address):
-        self.br.seek(address)
-        st = ""
-        while "\x00" not in st and len(st) < 0x1000:
-            x = self.br.read(255)
-            if x:
-                st += x
-                self.br.seek(address + len(st))
-            else:
-                break
-            log_debug("{!r}".format(st))
-        return st
-
     def get_pointer_at_virt(self, addr, size=None):
         x = self.bv.read(addr, self.ptr_size)
         if len(x) == 8:
@@ -129,7 +116,11 @@ class FunctionRenamer(GoHelper):
                 base_addr + entry_offset + self.ptr_size, 4)
             name_addr = base_addr + name_str_offset
 
-            name = self.read_cstring(name_addr)
+            name = self.bv.get_ascii_string_at(name_addr)
+            if not name:
+                continue
+            name=name.value
+
             log_debug("found name '{}' for address 0x{:x}"
                       .format(name, func_addr))
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,20 +1,31 @@
 {
-	"plugin": {
-		"name": "bn-goloader",
-		"type": ["binaryview"],
-		"api": "python2",
-		"description": "Short script that parses go symbol table and renames/creates functions.",
-		"longdescription": "",
-		"license": {
-			"name": "MIT",
-			"text": "Copyright (c) 2017 Michael Rodler (contact@f0rki.at)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-		},
-		"dependencies": {
-		},
-		"version": "0.1",
-		"author": "Michael Rodler",
-		"minimumBinaryNinjaVersion": {
-			"dev": "1.0"
-		}
-	}
+    "api": [
+        "python2",
+        "python3"
+    ],
+    "author": "Michael Rodler",
+    "dependencies": {},
+    "description": "Short script that parses go symbol table and renames/creates functions.",
+    "installinstructions": {
+        "Darwin": "no special instructions, package manager is recommended",
+        "Linux": "no special instructions, package manager is recommended",
+        "Windows": "no special instructions, package manager is recommended"
+    },
+    "license": {
+        "name": "MIT",
+        "text": "Copyright (c) 2017 Michael Rodler (contact@f0rki.at)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    },
+    "longdescription": "go reversing helpers for binaryninja.\n\nBasically this is some stuff ported from the IDA pro script\n[golang_load_assist](https://github.com/strazzere/golang_loader_assist)\n\n Probably incomplete!\n\n### go reversing blog posts\n\n * http://rednaga.io/2016/09/21/reversing_go_binaries_like_a_pro/",
+    "minimumbinaryninjaversion": 1528,
+    "name": "GO Loader Assist",
+    "platforms": [
+        "Darwin",
+        "Linux",
+        "Windows"
+    ],
+    "pluginmetadataversion": 2,
+    "type": [
+        "ui"
+    ],
+    "version": "1.1"
 }


### PR DESCRIPTION
Current plugin is broken on python3 because bv.read returns a bytes object and there's an api-built in to read the string out so, changed to use that instead. Best commit is negative total line count commit. 😉 