### PR TITLE
Change pattern type to bytes to match binja api

### DIFF
--- a/gohelpers.py
+++ b/gohelpers.py
@@ -86,7 +86,7 @@ class FunctionRenamer(GoHelper):
         gopclntab = self.get_section_by_name(".gopclntab")
 
         if gopclntab is None:
-            pattern = "\xfb\xff\xff\xff\x00\x00"
+            pattern = b"\xfb\xff\xff\xff\x00\x00"
             base_addr = self.bv.find_next_data(0, pattern)
 
             if base_addr is None:


### PR DESCRIPTION
Do not know if the binja API changed or if I have a weird python interpreter but somehow `find_next_data` only accept `bytes` even though the documentation says otherwise.

From the source code of binja:

```python
	def find_next_data(self, start: int, data: bytes, flags: FindFlag = FindFlag.FindCaseSensitive) -> Optional[int]:
		"""
                ...
		:param Union[bytes, bytearray, str] data: data to search for
                ...
		"""
		if not isinstance(data, bytes):
			raise TypeError("Must be bytes, bytearray, or str")
```

This simple fix made the trick for me